### PR TITLE
Update runner.sh

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -6,7 +6,7 @@ case "$1" in
     bash
     ;;
   jupyter)
-    jupyter notebook --no-browser --ip='*'
+    jupyter notebook --no-browser --allow-root --ip='*'
     ;;
   *)
     $@


### PR DESCRIPTION
Without allow root I get:
[C 04:34:37.886 NotebookApp] Running as root is not recommended. Use --allow-root to bypass.